### PR TITLE
`systemctl daemon-reload` After Installing Package

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -10,5 +10,9 @@
     - Stop cassandra
     - Clear cassandra data dir
 
+- name: Run `systemctl daemon-reload` command
+  command: 'systemctl daemon-reload'
+  when: cass_package|changed
+
 - meta: flush_handlers
 


### PR DESCRIPTION
`systemctl daemon-reload` needs to be ran after installing cassandra
package, otherwise systemd woundn't be able to start cassandra.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
